### PR TITLE
Looking a bit smarter for the flyby executable

### DIFF
--- a/update-tle
+++ b/update-tle
@@ -3,16 +3,17 @@
 tempfolder="/tmp/flyby-tle"
 tleurl="http://celestrak.com/NORAD/elements"
 
+# check if flyby is known to environment
+if hash flyby 2>/dev/null; then
+  flybybin=flyby
+fi
+
 if [ -x "./flyby" ]; then
   flybybin="./flyby"
 fi
 
 if [ -x "build/flyby" ]; then
   flybybin="build/flyby";
-fi
-
-if [ -x "/usr/local/bin/flyby" ]; then
-  flybybin="/usr/local/bin/flyby";
 fi
 
 if [ -n "$flybybin" ]; then


### PR DESCRIPTION
Using 'hash' to check if 'flyby' can be found by environment. Fixes flyby not found error under Arch Linux with binary in /usr/bin/ 