### PR TITLE
Issue 46, pass quality data in single track

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -1299,7 +1299,6 @@ void SingleTrack(int orbit_ind, predict_observer_t *qth, struct transponder_db *
 
 				//max elevation of current or next pass
 				max_elevation = predict_at_max_elevation(qth, orbital_elements, daynum);
-				predict_observe_orbit(qth, &temp_orbit, &max_elevation);
 			}
 
 			//display current time


### PR DESCRIPTION
Solves issue #46. Marking this as ready for merge through a pull request until https://github.com/la1k/libpredict/issues/62 is merged in libpredict's master.

Reformats AOS/LOS in singletrack mode and adds information about max elevation below. Not sure about the final layout, other configurations could be better, but this can also wait until #61 and #58.