### PR TITLE
Issue47, max elevation in multitrack

### DIFF
--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -484,9 +484,9 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 			gmtime_r(&epoch, &timeval);
 			if ((entry->next_los - time) > 1.0) {
 				int num_days = (entry->next_los - time);
-				snprintf(aos_los, MAX_NUM_CHARS, "%d days", num_days);
+				snprintf(aos_los, MAX_NUM_CHARS, ">%2.dd", num_days);
 			} else if (timeval.tm_hour > 0) {
-				strftime(aos_los, MAX_NUM_CHARS, "%H:%M:%S", &timeval);
+				strftime(aos_los, MAX_NUM_CHARS, ">%kh", &timeval);
 			} else {
 				strftime(aos_los, MAX_NUM_CHARS, "%M:%S", &timeval);
 			}
@@ -506,13 +506,13 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 			struct tm aostime, currtime;
 			gmtime_r(&aoslos_epoch, &aostime);
 			gmtime_r(&curr_epoch, &currtime);
-			aostime.tm_yday = aostime.tm_yday - currtime.tm_yday;
 			char temp[MAX_NUM_CHARS];
 			strftime(temp, MAX_NUM_CHARS, "%H:%MZ", &aostime);
-			if (aostime.tm_yday == 0) {
+			int num_days = entry->next_aos - time;
+			if (num_days == 0) {
 				strncpy(aos_los, temp, MAX_NUM_CHARS);
 			} else {
-				snprintf(aos_los, MAX_NUM_CHARS, "+%dd %s", aostime.tm_yday, temp);
+				snprintf(aos_los, MAX_NUM_CHARS, ">%2.dd", num_days);
 			}
 		}
 	} else if (!can_predict) {

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -470,6 +470,7 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 
 	//set text formatting attributes according to satellite state, set AOS/LOS string
 	bool can_predict = !predict_is_geostationary(entry->orbital_elements) && predict_aos_happens(entry->orbital_elements, qth->latitude) && !(orbit.decayed);
+	char pass_info[MAX_NUM_CHARS] = {0};
 	char aos_los[MAX_NUM_CHARS] = {0};
 
 	if (obs.elevation >= 0) {
@@ -543,8 +544,12 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 	}
 
 	char max_ele_str[MAX_NUM_CHARS] = {0};
+	snprintf(max_ele_str, MAX_NUM_CHARS, "%d", (int)(entry->max_elevation*180.0/M_PI));
+
 	if (can_predict) {
-		snprintf(max_ele_str, MAX_NUM_CHARS, "%d", (int)(entry->max_elevation*180.0/M_PI));
+		snprintf(pass_info, MAX_NUM_CHARS, "%s %6s", max_ele_str, aos_los);
+	} else {
+		snprintf(pass_info, MAX_NUM_CHARS, "%s", aos_los);
 	}
 
 	//altitude and range in km/miles
@@ -553,7 +558,7 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 
 	//set string to display
 	char disp_string[MAX_NUM_CHARS];
-	sprintf(disp_string, " %-10.8s%5.1f  %5.1f %8s%6.0f %6.0f %c %c %3s%9s ", entry->name, obs.azimuth*180.0/M_PI, obs.elevation*180.0/M_PI, abs_pos_string, disp_altitude, disp_range, sunstat, rangestat, max_ele_str, aos_los);
+	sprintf(disp_string, " %-10.8s%5.1f  %5.1f %8s%6.0f %6.0f %c %c %12s ", entry->name, obs.azimuth*180.0/M_PI, obs.elevation*180.0/M_PI, abs_pos_string, disp_altitude, disp_range, sunstat, rangestat, pass_info);
 
 	//overwrite everything if orbit was decayed
 	if (orbit.decayed) {

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -633,9 +633,20 @@ void multitrack_sort_listing(multitrack_listing_t *listing)
 	listing->num_nevervisible = nevervisible_counter;
 	listing->num_decayed = decayed_counter;
 
+	//sort those with nonzero elevation according to max elevation
+	for (int i=0; i < above_horizon_counter-1; i++) {
+		for (int j=0; j < above_horizon_counter-1; j++){
+			if (listing->entries[listing->sorted_index[j]]->max_elevation < listing->entries[listing->sorted_index[j+1]]->max_elevation) {
+				int x = listing->sorted_index[j];
+				listing->sorted_index[j] = listing->sorted_index[j+1];
+				listing->sorted_index[j+1] = x;
+			}
+		}
+	}
+
 	//sort internally according to AOS/LOS
-	for (int i=0; i < above_horizon_counter + below_horizon_counter; i++) {
-		for (int j=0; j < above_horizon_counter + below_horizon_counter - 1; j++){
+	for (int i=above_horizon_counter; i < above_horizon_counter + below_horizon_counter; i++) {
+		for (int j=above_horizon_counter; j < above_horizon_counter + below_horizon_counter - 1; j++){
 			if (listing->entries[listing->sorted_index[j]]->next_aos > listing->entries[listing->sorted_index[j+1]]->next_aos) {
 				int x = listing->sorted_index[j];
 				listing->sorted_index[j] = listing->sorted_index[j+1];

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -526,6 +526,12 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 	/* Calculate Next Event (AOS/LOS) Times */
 	if (can_predict && (time > entry->next_los) && (obs.elevation > 0)) {
 		entry->next_los= predict_next_los(qth, entry->orbital_elements, time);
+	}
+
+	if (can_predict && (time > entry->next_aos)) {
+		if (obs.elevation < 0) {
+			entry->next_aos = predict_next_aos(qth, entry->orbital_elements, time);
+		}
 		predict_julian_date_t max_ele_time = predict_max_elevation(qth, entry->orbital_elements, time);
 
 		struct predict_orbit orbit;
@@ -533,12 +539,6 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 		predict_orbit(entry->orbital_elements, &orbit, max_ele_time);
 		predict_observe_orbit(qth, &orbit, &observation);
 		entry->max_elevation = observation.elevation;
-	}
-
-	if (can_predict && (time > entry->next_aos)) {
-		if (obs.elevation < 0) {
-			entry->next_aos = predict_next_aos(qth, entry->orbital_elements, time);
-		}
 	}
 
 	//altitude and range in km/miles

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -279,7 +279,7 @@ void multitrack_resize(multitrack_listing_t *listing)
 	}
 
 	//make header line behave correctly
-	wresize(listing->header_window, 1, COLS);
+	wresize(listing->header_window, MULTITRACK_HEADER_HEIGHT, COLS);
 	wrefresh(listing->header_window);
 }
 
@@ -673,6 +673,8 @@ void multitrack_print_scrollbar(multitrack_listing_t *listing)
 	}
 }
 
+#define PASSINFO_HEADER_COL 52
+
 void multitrack_display_listing(multitrack_listing_t *listing)
 {
 	if ((listing->terminal_height != LINES) || (listing->terminal_width != COLS)) {
@@ -695,6 +697,9 @@ void multitrack_display_listing(multitrack_listing_t *listing)
 	char time_string[MAX_NUM_CHARS] = {0};
 	strftime(time_string, MAX_NUM_CHARS, "%H:%M:%SZ", gmtime(&epoch));
 	mvwprintw(listing->header_window, 0, strlen(header_text), "%s", time_string);
+
+	//print extra header info over maxele/aos/los
+	mvwprintw(listing->header_window, 1, PASSINFO_HEADER_COL, "Maxele  Time");
 
 	//show entries
 	if (listing->num_entries > 0) {

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -441,6 +441,10 @@ NCURSES_ATTR_T multitrack_colors(double range, double elevation)
 		return (COLOR_PAIR(2)|A_REVERSE); /* reverse */
 }
 
+#define SATELLITE_CLOSE_COLOR COLOR_PAIR(2)
+#define SATELLITE_FAR_COLOR COLOR_PAIR(4)
+#define SATELLITE_IGNORED_COLOR COLOR_PAIR(3)
+
 void multitrack_update_entry(double max_elevation_threshold, predict_observer_t *qth, multitrack_entry_t *entry, predict_julian_date_t time)
 {
 	entry->geostationary = false;
@@ -501,12 +505,12 @@ void multitrack_update_entry(double max_elevation_threshold, predict_observer_t 
 	} else if ((obs.elevation < 0) && can_predict) {
 		if ((entry->next_aos-time) < 0.00694) {
 			//satellite is close, set bold
-			entry->display_attributes = COLOR_PAIR(2);
+			entry->display_attributes = SATELLITE_CLOSE_COLOR;
 			time_t epoch = predict_from_julian(entry->next_aos - time);
 			strftime(aos_los, MAX_NUM_CHARS, "%M:%S", gmtime(&epoch)); //minutes and seconds left until AOS
 		} else {
 			//satellite is far, set normal coloring
-			entry->display_attributes = COLOR_PAIR(4);
+			entry->display_attributes = SATELLITE_FAR_COLOR;
 			time_t aoslos_epoch = predict_from_julian(entry->next_aos);
 			time_t curr_epoch = predict_from_julian(time);
 			struct tm aostime, currtime;
@@ -522,13 +526,13 @@ void multitrack_update_entry(double max_elevation_threshold, predict_observer_t 
 			}
 		}
 	} else if (!can_predict) {
-		entry->display_attributes = COLOR_PAIR(3);
+		entry->display_attributes = SATELLITE_IGNORED_COLOR;
 		sprintf(aos_los, "*GeoS-NoAOS*");
 	}
 
 	entry->above_max_elevation_threshold = entry->max_elevation > max_elevation_threshold;
 	if (!entry->above_max_elevation_threshold) {
-		entry->display_attributes = COLOR_PAIR(3);
+		entry->display_attributes = SATELLITE_IGNORED_COLOR;
 	}
 
 	char abs_pos_string[MAX_NUM_CHARS] = {0};

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -650,22 +650,38 @@ bool below_threshold(const multitrack_entry_t *entry)
 	return !entry->never_visible && !entry->above_max_elevation_threshold && !entry->decayed;
 }
 
+/**
+ * Used for sorting according to sort_value using qsort, but retain access to original index.
+ **/
 struct sort_helper {
 	int index;
 	double sort_value;
 };
 
+/**
+ * Comparison function for qsort (sort in ascending order).
+ **/
 int ascending(const void *lvalue, const void *rvalue)
 {
 	return ceil(((struct sort_helper*)lvalue)->sort_value - ((struct sort_helper*)rvalue)->sort_value);
 }
 
+/**
+ * Comparison function for qsort (sort in descending order).
+ **/
 int descending(const void *lvalue, const void *rvalue)
 {
 	return ceil(((struct sort_helper*)rvalue)->sort_value - ((struct sort_helper*)lvalue)->sort_value);
 }
 
-
+/**
+ * Sort entry_mapping according to satellite values and sorting options.
+ *
+ * \param entries Satellite entries
+ * \param num_entries Number of entries in entry_mapping
+ * \param entry_mapping Entry mapping, maps indices in entries
+ * \param sort_option Sorting option defined in enum sort_options. Currently assumed to be either SORT_BY_AOS (sort by next_aos field in ascending order) or SORT_BY_MAX_ELEVATION (sort by max_elevation in descending order)
+ **/
 void sort_satellites(multitrack_entry_t **entries, int num_entries, int *entry_mapping, int sort_option)
 {
 	//prepare array for sorting using stdlib's qsort

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -632,25 +632,6 @@ void multitrack_update_listing_data(multitrack_listing_t *listing, predict_julia
 }
 
 /**
- * Helper functions for category sorting of multitrack listing.
- **/
-
-bool above_horizon(const multitrack_entry_t *entry)
-{
-	return entry->above_horizon && !entry->decayed && entry->above_max_elevation_threshold;
-}
-
-bool will_rise(const multitrack_entry_t *entry)
-{
-	return !(entry->above_horizon) && !(entry->never_visible) && !(entry->decayed) && entry->above_max_elevation_threshold;
-}
-
-bool below_threshold(const multitrack_entry_t *entry)
-{
-	return !entry->never_visible && !entry->above_max_elevation_threshold && !entry->decayed;
-}
-
-/**
  * Used for sorting according to sort_value using qsort, but retain access to original index.
  **/
 struct sort_helper {
@@ -708,6 +689,25 @@ void sort_satellites(multitrack_entry_t **entries, int num_entries, int *entry_m
 	}
 
 	free(sorting);
+}
+
+/**
+ * Helper functions for category sorting of multitrack listing.
+ **/
+
+bool above_horizon(const multitrack_entry_t *entry)
+{
+	return entry->above_horizon && !entry->decayed && entry->above_max_elevation_threshold;
+}
+
+bool will_rise(const multitrack_entry_t *entry)
+{
+	return !(entry->above_horizon) && !(entry->never_visible) && !(entry->decayed) && entry->above_max_elevation_threshold;
+}
+
+bool below_threshold(const multitrack_entry_t *entry)
+{
+	return !entry->never_visible && !entry->above_max_elevation_threshold && !entry->decayed;
 }
 
 void multitrack_sort_listing(multitrack_listing_t *listing)

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -1539,7 +1539,7 @@ void multitrack_edit_settings(multitrack_listing_t *listing)
 	wattrset(option_window, COLOR_PAIR(4));
 	col = 1;
 	row++;
-	mvwprintw(option_window, row++, col, "Press ESC or ENTER to return");
+	mvwprintw(option_window, row++, col, "Press q or ENTER to return");
 
 	//resize window to contents
 	wresize(option_window, row+1, OPTION_WINDOW_WIDTH);
@@ -1649,8 +1649,8 @@ void multitrack_edit_settings(multitrack_listing_t *listing)
 					}
 				}
 				break;
+			case 'q':
 			case 10:
-			case 23:
 				run = false;
 				break;
 			default:

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -1441,8 +1441,9 @@ void multitrack_edit_settings(multitrack_listing_t *listing)
 	set_field_back(max_ele_field, FIELDSTYLE_INACTIVE);
 	FIELD *max_ele_field_desc = new_field(field_height, field_width, field_row, CHECKOPT_STRLEN, 0, 0);
 	field_opts_off(max_ele_field, O_STATIC);
-	set_max_field(max_ele_field, MAX_NUM_CHARS);
+	set_max_field(max_ele_field, CHECKOPT_STRLEN-1);
 	set_max_field(max_ele_field_desc, MAX_NUM_CHARS);
+	field_opts_off(max_ele_field_desc, O_ACTIVE);
 	FIELD *fields[3] = {max_ele_field, max_ele_field_desc, NULL};
 	FORM *form = new_form(fields);
 
@@ -1486,6 +1487,9 @@ void multitrack_edit_settings(multitrack_listing_t *listing)
 					in_form = false;
 				}
 				break;
+			case KEY_BACKSPACE:
+				form_driver(form, REQ_CLR_FIELD);
+				break;
 			case ' ':
 				if (in_checklist) {
 					selected_item = item_index(current_item(checklist->menu));
@@ -1500,6 +1504,9 @@ void multitrack_edit_settings(multitrack_listing_t *listing)
 						}
 					}
 				}
+				break;
+			default:
+				form_driver(form, c);
 			break;
 		}
                 wrefresh(option_window);

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -1456,7 +1456,11 @@ void multitrack_edit_settings(multitrack_listing_t *listing)
 		}
                 wrefresh(option_window);
 	}
-
+		if (checklist_item_checked(checklist, sort_by_aos_ind)) {
+			listing->sort_option = SORT_BY_AOS;
+		} else {
+			listing->sort_option = SORT_BY_MAX_ELEVATION;
+		}
 
 
 

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -312,6 +312,8 @@ multitrack_listing_t* multitrack_create_listing(predict_observer_t *observer, st
 
 	listing->terminal_height = LINES;
 	listing->terminal_width = LINES;
+
+	listing->sort_option = SORT_BY_MAX_ELEVATION;
 	return listing;
 }
 
@@ -633,24 +635,36 @@ void multitrack_sort_listing(multitrack_listing_t *listing)
 	listing->num_nevervisible = nevervisible_counter;
 	listing->num_decayed = decayed_counter;
 
-	//sort those with nonzero elevation according to max elevation
-	for (int i=0; i < above_horizon_counter-1; i++) {
-		for (int j=0; j < above_horizon_counter-1; j++){
-			if (listing->entries[listing->sorted_index[j]]->max_elevation < listing->entries[listing->sorted_index[j+1]]->max_elevation) {
-				int x = listing->sorted_index[j];
-				listing->sorted_index[j] = listing->sorted_index[j+1];
-				listing->sorted_index[j+1] = x;
+	if (listing->sort_option == SORT_BY_AOS) {
+		//sort those with nonzero elevation according to max elevation
+		for (int i=0; i < above_horizon_counter-1; i++) {
+			for (int j=0; j < above_horizon_counter-1; j++){
+				if (listing->entries[listing->sorted_index[j]]->max_elevation < listing->entries[listing->sorted_index[j+1]]->max_elevation) {
+					int x = listing->sorted_index[j];
+					listing->sorted_index[j] = listing->sorted_index[j+1];
+					listing->sorted_index[j+1] = x;
+				}
 			}
 		}
-	}
 
-	//sort internally according to AOS/LOS
-	for (int i=above_horizon_counter; i < above_horizon_counter + below_horizon_counter; i++) {
-		for (int j=above_horizon_counter; j < above_horizon_counter + below_horizon_counter - 1; j++){
-			if (listing->entries[listing->sorted_index[j]]->next_aos > listing->entries[listing->sorted_index[j+1]]->next_aos) {
-				int x = listing->sorted_index[j];
-				listing->sorted_index[j] = listing->sorted_index[j+1];
-				listing->sorted_index[j+1] = x;
+		//sort internally according to AOS/LOS
+		for (int i=above_horizon_counter; i < above_horizon_counter + below_horizon_counter; i++) {
+			for (int j=above_horizon_counter; j < above_horizon_counter + below_horizon_counter - 1; j++){
+				if (listing->entries[listing->sorted_index[j]]->next_aos > listing->entries[listing->sorted_index[j+1]]->next_aos) {
+					int x = listing->sorted_index[j];
+					listing->sorted_index[j] = listing->sorted_index[j+1];
+					listing->sorted_index[j+1] = x;
+				}
+			}
+		}
+	} else if (listing->sort_option == SORT_BY_MAX_ELEVATION) {
+		for (int i=0; i < above_horizon_counter + below_horizon_counter; i++) {
+			for (int j=0; j < above_horizon_counter + below_horizon_counter - 1; j++){
+				if (listing->entries[listing->sorted_index[j]]->max_elevation < listing->entries[listing->sorted_index[j+1]]->max_elevation) {
+					int x = listing->sorted_index[j];
+					listing->sorted_index[j] = listing->sorted_index[j+1];
+					listing->sorted_index[j+1] = x;
+				}
 			}
 		}
 	}

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -526,6 +526,13 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 	/* Calculate Next Event (AOS/LOS) Times */
 	if (can_predict && (time > entry->next_los) && (obs.elevation > 0)) {
 		entry->next_los= predict_next_los(qth, entry->orbital_elements, time);
+		predict_julian_date_t max_ele_time = predict_max_elevation(qth, entry->orbital_elements, time);
+
+		struct predict_orbit orbit;
+		struct predict_observation observation;
+		predict_orbit(entry->orbital_elements, &orbit, max_ele_time);
+		predict_observe_orbit(qth, &orbit, &observation);
+		entry->max_elevation = observation.elevation;
 	}
 
 	if (can_predict && (time > entry->next_aos)) {

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -687,24 +687,40 @@ void multitrack_display_entry(WINDOW *window, int row, int col, multitrack_entry
 	mvwprintw(window, row, col, "%s", entry->display_string);
 }
 
+#define MULTITRACK_OPTION_WINDOW_WIDTH 70
+#define MULTITRACK_OPTION_WINDOW_ROW 7
+#define MULTITRACK_OPTION_WINDOW_COL 3
+
 void multitrack_options(multitrack_listing_t *listing)
 {
-	WINDOW *option_window = newwin(30, 70, 4, 3);
+	WINDOW *option_window = newwin(LINES, MULTITRACK_OPTION_WINDOW_WIDTH, MULTITRACK_OPTION_WINDOW_ROW, MULTITRACK_OPTION_WINDOW_COL);
 
 	int row = 1;
-	mvwprintw(option_window, row++, 1, "Keybindings:");
-	mvwprintw(option_window, row++, 1, "F3/`/`:  Search for satellite");
+	int col = 1;
+	mvwprintw(option_window, row++, col, "[*] Sort by AOS");
+	mvwprintw(option_window, row++, col, "[ ] Sort by max elevation");
+	mvwprintw(option_window, row++, col, "    Max elevation threshold");
+
+	col = 1;
 	row++;
-	mvwprintw(option_window, row++, 1, "Colorscheme:");
+	int help_row = row;
+	mvwprintw(option_window, row++, col, "Keybindings:");
+	mvwprintw(option_window, row++, col, "F3/`/`:  Search for satellite");
+	row = help_row;
+	col = 32;
+
+	mvwprintw(option_window, row++, col, "Colorscheme:");
 
 	wattrset(option_window, multitrack_colors(3000, 1));
-	mvwprintw(option_window, row++, 1, "Satellite above horizon");
+	mvwprintw(option_window, row++, col, "Satellite above horizon");
 	wattrset(option_window, SATELLITE_CLOSE_COLOR);
-	mvwprintw(option_window, row++, 1, "Satellite about to pass over horizon");
+	mvwprintw(option_window, row++, col, "Satellite about to pass over horizon");
 	wattrset(option_window, SATELLITE_FAR_COLOR);
-	mvwprintw(option_window, row++, 1, "Satellite scheduled to pass over horizon");
+	mvwprintw(option_window, row++, col, "Satellite scheduled for pass");
 	wattrset(option_window, SATELLITE_IGNORED_COLOR);
-	mvwprintw(option_window, row++, 1, "Ignored satellite");
+	mvwprintw(option_window, row++, col, "Ignored satellite");
+
+	wresize(option_window, row+1, MULTITRACK_OPTION_WINDOW_WIDTH);
 
 
 	wattrset(option_window, COLOR_PAIR(4));

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -687,6 +687,36 @@ void multitrack_display_entry(WINDOW *window, int row, int col, multitrack_entry
 	mvwprintw(window, row, col, "%s", entry->display_string);
 }
 
+void multitrack_options(multitrack_listing_t *listing)
+{
+	WINDOW *option_window = newwin(30, 70, 4, 3);
+
+	int row = 1;
+	mvwprintw(option_window, row++, 1, "Keybindings:");
+	mvwprintw(option_window, row++, 1, "F3/`/`:  Search for satellite");
+	row++;
+	mvwprintw(option_window, row++, 1, "Colorscheme:");
+
+	wattrset(option_window, multitrack_colors(3000, 1));
+	mvwprintw(option_window, row++, 1, "Satellite above horizon");
+	wattrset(option_window, SATELLITE_CLOSE_COLOR);
+	mvwprintw(option_window, row++, 1, "Satellite about to pass over horizon");
+	wattrset(option_window, SATELLITE_FAR_COLOR);
+	mvwprintw(option_window, row++, 1, "Satellite scheduled to pass over horizon");
+	wattrset(option_window, SATELLITE_IGNORED_COLOR);
+	mvwprintw(option_window, row++, 1, "Ignored satellite");
+
+
+	wattrset(option_window, COLOR_PAIR(4));
+	box(option_window, 0, 0);
+	wrefresh(option_window);
+
+	cbreak(); //turn off halfdelay mode so that getch blocks
+	getch();
+
+	delwin(option_window);
+}
+
 void multitrack_print_scrollbar(multitrack_listing_t *listing)
 {
 	int scrollarea_offset = 0;

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -566,13 +566,9 @@ void multitrack_update_entry(double max_elevation_threshold, predict_observer_t 
 		if (obs.elevation < 0) {
 			entry->next_aos = predict_next_aos(qth, entry->orbital_elements, time);
 		}
-		predict_julian_date_t max_ele_time = predict_max_elevation(qth, entry->orbital_elements, time);
 
-		struct predict_orbit orbit;
-		struct predict_observation observation;
-		predict_orbit(entry->orbital_elements, &orbit, max_ele_time);
-		predict_observe_orbit(qth, &orbit, &observation);
-		entry->max_elevation = observation.elevation*180.0/M_PI;
+		struct predict_observation max_elevation_obs = predict_at_max_elevation(qth, entry->orbital_elements, time);
+		entry->max_elevation = max_elevation_obs.elevation*180.0/M_PI;
 	}
 
 	//use current elevation as max elevation if satellite is above horizon and geostationary

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -1589,39 +1589,60 @@ void checklist_free(struct checklist **input_checklist)
 //start column for multitrack option window
 #define OPTION_WINDOW_COL 3
 
+#define OPTION_WINDOW_HEIGHT 7
+
+void multitrack_show_help()
+{
+	WINDOW *help_window = newwin(LINES, OPTION_WINDOW_WIDTH, OPTION_WINDOW_ROW, OPTION_WINDOW_COL);
+
+	//print keybindings/color scheme cheatsheet in help window
+	int row = 1;
+	int col = 1;
+	int help_row = row;
+	mvwprintw(help_window, row++, col, "Keybindings:");
+	mvwprintw(help_window, row++, col, "F3/`/`:  Search for satellite");
+	row = help_row;
+	col = 32;
+	mvwprintw(help_window, row++, col, "Colorscheme:");
+	wattrset(help_window, multitrack_colors(3000, 1));
+	mvwprintw(help_window, row++, col, "Satellite above horizon");
+	wattrset(help_window, SATELLITE_CLOSE_COLOR);
+	mvwprintw(help_window, row++, col, "Satellite about to pass over horizon");
+	wattrset(help_window, SATELLITE_FAR_COLOR);
+	mvwprintw(help_window, row++, col, "Satellite scheduled for pass");
+	wattrset(help_window, SATELLITE_IGNORED_COLOR);
+	mvwprintw(help_window, row++, col, "Ignored satellite");
+	wattrset(help_window, COLOR_PAIR(4));
+	col = 1;
+
+	//resize and add border
+	wresize(help_window, row+1, OPTION_WINDOW_WIDTH);
+	box(help_window, 0, 0);
+
+	//title
+	mvwprintw(help_window, 0, 3, "Multitrack help");
+
+	wrefresh(help_window);
+
+	cbreak(); //turn off halfdelay mode so that getch blocks
+	getch();
+	delwin(help_window);
+}
+
 void multitrack_edit_settings(multitrack_listing_t *listing)
 {
 	cbreak(); //turn off halfdelay mode so that getch blocks
-	WINDOW *option_window = newwin(LINES, OPTION_WINDOW_WIDTH, OPTION_WINDOW_ROW, OPTION_WINDOW_COL);
+	WINDOW *option_window = newwin(OPTION_WINDOW_HEIGHT, OPTION_WINDOW_WIDTH, OPTION_WINDOW_ROW, OPTION_WINDOW_COL);
 
-	//print keybindings/color scheme cheatsheet
-	int row = 5;
 	int col = 1;
-	int help_row = row;
-	mvwprintw(option_window, row++, col, "Keybindings:");
-	mvwprintw(option_window, row++, col, "F3/`/`:  Search for satellite");
-	row = help_row;
-	col = 32;
-	mvwprintw(option_window, row++, col, "Colorscheme:");
-	wattrset(option_window, multitrack_colors(3000, 1));
-	mvwprintw(option_window, row++, col, "Satellite above horizon");
-	wattrset(option_window, SATELLITE_CLOSE_COLOR);
-	mvwprintw(option_window, row++, col, "Satellite about to pass over horizon");
-	wattrset(option_window, SATELLITE_FAR_COLOR);
-	mvwprintw(option_window, row++, col, "Satellite scheduled for pass");
-	wattrset(option_window, SATELLITE_IGNORED_COLOR);
-	mvwprintw(option_window, row++, col, "Ignored satellite");
-	wattrset(option_window, COLOR_PAIR(4));
-	col = 1;
-	row++;
-	mvwprintw(option_window, row++, col, "Press q or ENTER to return");
 
-	//resize window to contents
-	wresize(option_window, row+1, OPTION_WINDOW_WIDTH);
+	//window border and exit hint
+	wattrset(option_window, COLOR_PAIR(4));
+	mvwprintw(option_window, OPTION_WINDOW_HEIGHT-2, col, "Press q or ENTER to return");
 	box(option_window, 0, 0);
 
 	//window title
-	mvwprintw(option_window, 0, 3, "Multitrack settings/help");
+	mvwprintw(option_window, 0, 3, "Multitrack settings");
 
 	//radio button menu for selecting sorting options
 	const char *sort_settings_names[NUM_SORT_SETTINGS] = {"Sort by AOS", "Sort by max elevation"};

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -254,6 +254,8 @@ multitrack_entry_t *multitrack_create_entry(const char *name, predict_orbital_el
 	entry->geostationary = 0;
 	entry->never_visible = 0;
 	entry->decayed = 0;
+	entry->max_elevation = 0;
+	entry->above_max_elevation_threshold = true;
 	return entry;
 }
 

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -471,6 +471,7 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 	//set text formatting attributes according to satellite state, set AOS/LOS string
 	bool can_predict = !predict_is_geostationary(entry->orbital_elements) && predict_aos_happens(entry->orbital_elements, qth->latitude) && !(orbit.decayed);
 	char aos_los[MAX_NUM_CHARS] = {0};
+
 	if (obs.elevation >= 0) {
 		//different colours according to range and elevation
 		entry->display_attributes = multitrack_colors(obs.range, obs.elevation*180/M_PI);
@@ -541,13 +542,18 @@ void multitrack_update_entry(predict_observer_t *qth, multitrack_entry_t *entry,
 		entry->max_elevation = observation.elevation;
 	}
 
+	char max_ele_str[MAX_NUM_CHARS] = {0};
+	if (can_predict) {
+		snprintf(max_ele_str, MAX_NUM_CHARS, "%d", (int)(entry->max_elevation*180.0/M_PI));
+	}
+
 	//altitude and range in km/miles
 	double disp_altitude = orbit.altitude;
 	double disp_range = obs.range;
 
 	//set string to display
 	char disp_string[MAX_NUM_CHARS];
-	sprintf(disp_string, " %-10.8s%5.1f  %5.1f %8s%6.0f %6.0f %c %c %12s ", entry->name, obs.azimuth*180.0/M_PI, obs.elevation*180.0/M_PI, abs_pos_string, disp_altitude, disp_range, sunstat, rangestat, aos_los);
+	sprintf(disp_string, " %-10.8s%5.1f  %5.1f %8s%6.0f %6.0f %c %c %3s%9s ", entry->name, obs.azimuth*180.0/M_PI, obs.elevation*180.0/M_PI, abs_pos_string, disp_altitude, disp_range, sunstat, rangestat, max_ele_str, aos_los);
 
 	//overwrite everything if orbit was decayed
 	if (orbit.decayed) {

--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -631,7 +631,7 @@ void multitrack_sort_listing(multitrack_listing_t *listing)
 
 	//those with elevation > 0 at the top
 	int above_horizon_counter = 0;
-	for (int i=0; i < num_orbits; i++){
+	for (int i=0; i < num_orbits; i++) {
 		if (listing->entries[i]->above_horizon && !(listing->entries[i]->decayed) && listing->entries[i]->above_max_elevation_threshold) {
 			listing->sorted_index[above_horizon_counter] = i;
 			above_horizon_counter++;
@@ -641,7 +641,7 @@ void multitrack_sort_listing(multitrack_listing_t *listing)
 
 	//satellites that will eventually rise above the horizon
 	int below_horizon_counter = 0;
-	for (int i=0; i < num_orbits; i++){
+	for (int i=0; i < num_orbits; i++) {
 		if (!(listing->entries[i]->above_horizon) && !(listing->entries[i]->never_visible) && !(listing->entries[i]->decayed) && listing->entries[i]->above_max_elevation_threshold) {
 			listing->sorted_index[below_horizon_counter + above_horizon_counter] = i;
 			below_horizon_counter++;
@@ -649,12 +649,22 @@ void multitrack_sort_listing(multitrack_listing_t *listing)
 	}
 	listing->num_below_horizon = below_horizon_counter;
 
+	//satellites below max elevation threshold
+	int below_threshold_counter = 0;
+	for (int i=0; i < num_orbits; i++) {
+		if (!listing->entries[i]->never_visible && !listing->entries[i]->above_max_elevation_threshold && !listing->entries[i]->decayed) {
+			listing->sorted_index[below_horizon_counter + above_horizon_counter + below_threshold_counter] = i;
+			below_threshold_counter++;
+		}
+	}
+	listing->num_below_threshold = below_threshold_counter;
+
 	//satellites that will never be visible, with decayed orbits last
 	int nevervisible_counter = 0;
 	int decayed_counter = 0;
-	for (int i=0; i < num_orbits; i++){
-		if ((listing->entries[i]->never_visible || !listing->entries[i]->above_max_elevation_threshold) && !(listing->entries[i]->decayed)) {
-			listing->sorted_index[below_horizon_counter + above_horizon_counter + nevervisible_counter] = i;
+	for (int i=0; i < num_orbits; i++) {
+		if (listing->entries[i]->never_visible && !(listing->entries[i]->decayed)) {
+			listing->sorted_index[below_horizon_counter + above_horizon_counter + below_threshold_counter + nevervisible_counter] = i;
 			nevervisible_counter++;
 		} else if (listing->entries[i]->decayed) {
 			listing->sorted_index[num_orbits - 1 - decayed_counter] = i;

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -14,6 +14,8 @@
 //Start row for multitrack window printing
 #define MULTITRACK_WINDOW_ROW (MULTITRACK_HEADER_HEIGHT+1)
 
+enum sort_options{SORT_BY_AOS, SORT_BY_MAX_ELEVATION};
+
 /**
  * Structs and functions used for showing a navigateable real-time satellite listing.
  **/
@@ -150,6 +152,8 @@ typedef struct {
 	int terminal_height;
 	///Current terminal width
 	int terminal_width;
+	///Sorting options
+	int sort_option;
 } multitrack_listing_t;
 
 /**

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -8,8 +8,11 @@
 //Width of multitrack window
 #define MULTITRACK_WINDOW_WIDTH 67
 
+//Height of multitrack header window
+#define MULTITRACK_HEADER_HEIGHT 2
+
 //Start row for multitrack window printing
-#define MULTITRACK_WINDOW_ROW 2
+#define MULTITRACK_WINDOW_ROW (MULTITRACK_HEADER_HEIGHT+1)
 
 /**
  * Structs and functions used for showing a navigateable real-time satellite listing.

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -140,6 +140,8 @@ typedef struct {
 	int num_above_horizon;
 	///Current number of satellites below the horizon (but will eventually rise) (displayed next, next part of sorted mapping)
 	int num_below_horizon;
+	///Number of satellites below max elevation threshold
+	int num_below_threshold;
 	///Number of satellites that will never be visible from the current QTH
 	int num_nevervisible;
 	///Number of decayed satellites (last part of menu listing, last part of sorted mapping)

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -205,11 +205,16 @@ void multitrack_display_listing(multitrack_listing_t *listing);
 bool multitrack_handle_listing(multitrack_listing_t *listing, int input_key);
 
 /**
- * Edit multitrack options.
+ * Edit multitrack options. Will save to config file on exit.
  *
  * \param listing Multitrack listing
  **/
 void multitrack_edit_settings(multitrack_listing_t *listing);
+
+/**
+ * Show help window.
+ **/
+void multitrack_show_help();
 
 /**
  * Return currently selected entry, in terms of index in the TLE database.

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -203,6 +203,11 @@ void multitrack_display_listing(multitrack_listing_t *listing);
 bool multitrack_handle_listing(multitrack_listing_t *listing, int input_key);
 
 /**
+ * Edit multitrack options.
+ **/
+void multitrack_options(multitrack_listing_t *listing);
+
+/**
  * Return currently selected entry, in terms of index in the TLE database.
  *
  * \param listing Satellite listing

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -204,8 +204,10 @@ bool multitrack_handle_listing(multitrack_listing_t *listing, int input_key);
 
 /**
  * Edit multitrack options.
+ *
+ * \param listing Multitrack listing
  **/
-void multitrack_options(multitrack_listing_t *listing);
+void multitrack_edit_settings(multitrack_listing_t *listing);
 
 /**
  * Return currently selected entry, in terms of index in the TLE database.

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -27,6 +27,8 @@ typedef struct {
 	double next_aos;
 	///Time for next LOS
 	double next_los;
+	///Maximum elevation of the next or current pass
+	double max_elevation;
 	///Whether satellite currently is above horizon
 	bool above_horizon;
 	///Whether satellite is geostationary

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -160,6 +160,8 @@ typedef struct {
 	int sort_option;
 	///Max elevation threshold in degrees
 	double max_elevation_threshold;
+	///Whether listing should be sorted in multitrack_update_listing_data().
+	bool should_sort;
 } multitrack_listing_t;
 
 /**

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -32,7 +32,7 @@ typedef struct {
 	double next_aos;
 	///Time for next LOS
 	double next_los;
-	///Maximum elevation of the next or current pass
+	///Maximum elevation of the next or current pass in degrees
 	double max_elevation;
 	///Whether satellite currently is above horizon
 	bool above_horizon;
@@ -156,7 +156,7 @@ typedef struct {
 	int terminal_width;
 	///Sorting options
 	int sort_option;
-	///Thresholding options
+	///Max elevation threshold in degrees
 	double max_elevation_threshold;
 } multitrack_listing_t;
 

--- a/src/multitrack.h
+++ b/src/multitrack.h
@@ -40,6 +40,8 @@ typedef struct {
 	bool geostationary;
 	///Whether satellite is never visible
 	bool never_visible;
+	///Whether satellite is above maximum elevation threshold
+	bool above_max_elevation_threshold;
 	///Whether satellite has decayed
 	bool decayed;
 	///String used for information displaying in the satellite listing
@@ -154,6 +156,8 @@ typedef struct {
 	int terminal_width;
 	///Sorting options
 	int sort_option;
+	///Thresholding options
+	double max_elevation_threshold;
 } multitrack_listing_t;
 
 /**

--- a/src/ui.c
+++ b/src/ui.c
@@ -2516,6 +2516,11 @@ void RunFlybyUI(bool new_user, const char *qthfile, predict_observer_t *observer
 							multitrack_edit_settings(listing);
 							break;
 
+						case 'H':
+						case 'h':
+							multitrack_show_help();
+							break;
+
 						case 'G':
 						case 'g':
 							QthEdit(qthfile, observer);

--- a/src/ui.c
+++ b/src/ui.c
@@ -2008,7 +2008,8 @@ void PrintMainMenu(WINDOW *window)
 	column = PrintMainMenuOption(window, row, column, 'N', "Lunar Pass Predictions   ");
 	column = 0;
 	row++;
-	column = PrintMainMenuOption(window, row, column, 'U', "Update Sat Elements                                ");
+	column = PrintMainMenuOption(window, row, column, 'U', "Update Sat Elements      ");
+	column = PrintMainMenuOption(window, row, column, 'M', "Multitrack settings      ");
 	column = PrintMainMenuOption(window, row, column, 'Q', "Exit flyby               ");
 
 	wrefresh(window);

--- a/src/ui.c
+++ b/src/ui.c
@@ -2512,7 +2512,7 @@ void RunFlybyUI(bool new_user, const char *qthfile, predict_observer_t *observer
 
 						case 'M':
 						case 'm':
-							multitrack_options(listing);
+							multitrack_edit_settings(listing);
 							break;
 
 						case 'G':

--- a/src/ui.c
+++ b/src/ui.c
@@ -2510,6 +2510,11 @@ void RunFlybyUI(bool new_user, const char *qthfile, predict_observer_t *observer
 							AutoUpdate("", tle_db);
 							break;
 
+						case 'M':
+						case 'm':
+							multitrack_options(listing);
+							break;
+
 						case 'G':
 						case 'g':
 							QthEdit(qthfile, observer);

--- a/src/xdg_basedirs.h
+++ b/src/xdg_basedirs.h
@@ -16,6 +16,9 @@
 //default relative whitelist filename
 #define WHITELIST_RELATIVE_FILE_PATH FLYBY_RELATIVE_ROOT_PATH "flyby.whitelist"
 
+//default relative multitrack settings filename
+#define MULTITRACK_SETTINGS_FILE FLYBY_RELATIVE_ROOT_PATH "multitrack_settings.conf"
+
 /**
  * \return XDG_DATA_DIRS variable, or the xdg basedir specification default if the environment variable is empty
  **/


### PR DESCRIPTION
Solves issue #47 and #48. Marking this as ready for merge through a pull request until la1k/libpredict#62 is merged in libpredict's master.

Adds max elevation info to multitrack, in addition to filtering and sorting options.