### PR TITLE
Make the user aware of the libpredict dependency with help of cmake/pkg-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,10 @@ before_script:
   - mkdir $LIBPREDICT_FOLDER
   - cd libpredict-master && mkdir -p build; cd build; cmake -D CMAKE_INSTALL_PREFIX=$LIBPREDICT_FOLDER .. && make && make install
   - export LIBPREDICT_LIBRARY_PATH="$LIBPREDICT_FOLDER/lib/"
-  - export LIBPREDICT_INCLUDE_PATH="$LIBPREDICT_FOLDER/include"
   - export LD_LIBRARY_PATH="$LIBPREDICT_LIBRARY_PATH"
   - cd $ORIG_FOLDER
 
-script: mkdir -p build; cd build; cmake --version && cmake -D CMAKE_C_FLAGS="-I $LIBPREDICT_INCLUDE_PATH -L $LIBPREDICT_LIBRARY_PATH" .. && make
+script: mkdir -p build; cd build; cmake --version && PKG_CONFIG_PATH=$LIBPREDICT_LIBRARY_PATH/pkgconfig cmake .. && make
 
 notifications:
   email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,18 +25,22 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 configure_file(src/config.h.in config.h @ONLY)
 add_definitions(-std=gnu99)
 
-include_directories(${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/src)
+find_package(PkgConfig)
+pkg_search_module(PREDICT REQUIRED predict)
+
+include_directories(${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/src ${PREDICT_INCLUDE_DIRS})
+link_directories(${PREDICT_LIBRARY_DIRS})
 
 #main flyby executable
 add_executable(flyby src/ui.c src/hamlib.c src/main.c src/string_array.c src/xdg_basedirs.c src/tle_db.c src/transponder_db.c src/qth_config.c src/filtered_menu.c src/transponder_editor.c src/multitrack.c src/locator.c src/option_help.c src/singletrack.c src/prediction_schedules.c src/hamlib_settings.c)
 install(TARGETS flyby RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-target_link_libraries(flyby m ncurses menu form predict)
+target_link_libraries(flyby m ncurses menu form ${PREDICT_LIBRARIES})
 
 #transponder database utility
 set(TRANSPONDER_UTILITY_NAME "flyby-transponder-dbutil") #name of transponder utility executable
 add_executable(transponder_utility src/transponder_utility.c src/tle_db.c src/transponder_db.c src/string_array.c src/xdg_basedirs.c src/option_help.c)
-target_link_libraries(transponder_utility predict m)
+target_link_libraries(transponder_utility ${PREDICT_LIBRARIES} m)
 install(TARGETS transponder_utility RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 set_target_properties(transponder_utility PROPERTIES OUTPUT_NAME "${TRANSPONDER_UTILITY_NAME}")
 


### PR DESCRIPTION
Makes https://github.com/la1k/flyby/issues/78 more clear as cmake will warn about libpredict not being found.