### PR TITLE
Updated selector indicator to be an underline

### DIFF
--- a/src/multitrack.c
+++ b/src/multitrack.c
@@ -13,7 +13,7 @@
 #define HEADER_STYLE COLOR_PAIR(2)|A_REVERSE
 
 //color attributes of selected entry in satellite listing
-#define MULTITRACK_SELECTED_ATTRIBUTE (COLOR_PAIR(6)|A_REVERSE)
+#define MULTITRACK_SELECTED_ATTRIBUTE A_UNDERLINE
 
 //marker of menu item
 #define MULTITRACK_SELECTED_MARKER '-'
@@ -835,7 +835,7 @@ void multitrack_display_listing(multitrack_listing_t *listing)
 	//show entries
 	if (listing->num_entries > 0) {
 		int selected_index = listing->sorted_index[listing->selected_entry_index];
-		listing->entries[selected_index]->display_attributes = MULTITRACK_SELECTED_ATTRIBUTE;
+		listing->entries[selected_index]->display_attributes |= MULTITRACK_SELECTED_ATTRIBUTE;
 		listing->entries[selected_index]->display_string[0] = MULTITRACK_SELECTED_MARKER;
 
 		int line = 0;


### PR DESCRIPTION
In the multitrack listing, the old selector of a red bar overwrote the
coloring and highlighting of each satellite.  With this change, the
multitrack selector is an underline that matches the current color and
highlighting of each satellite

Compare:
![Screenshot_flyby _home_dkruse_code_libpredict git_1](https://user-images.githubusercontent.com/382446/144481171-57d482cc-63b7-47dc-92e1-e2401b000258.png)

to:
![Screenshot_flyby _home_dkruse_code_libpredict git_5](https://user-images.githubusercontent.com/382446/144481310-33ce565c-a66e-4e45-a558-20d32394cc57.png)
.