### PR TITLE
Use non-blocking socket reads for rotctl track responses

### DIFF
--- a/src/hamlib.h
+++ b/src/hamlib.h
@@ -30,6 +30,12 @@ typedef struct {
 	double prev_cmd_azimuth;
 	///Previous sent elevation
 	double prev_cmd_elevation;
+	///Whether the response from the last track command has been received
+	bool last_track_response_received;
+	///Current position in the buffer for reading response from the last track command
+	int track_buffer_pos;
+	///Buffer for reading the response of the last track command
+	char track_buffer[MAX_NUM_CHARS];
 } rotctld_info_t;
 
 typedef struct {
@@ -54,6 +60,8 @@ enum rotctld_error_e {
 	ROTCTLD_CONNECTION_FAILED = -2,
 	ROTCTLD_SEND_FAILED = -3,
 	ROTCTLD_RETURNED_STATUS_ERROR = -4,
+	ROTCTLD_READ_BUFFER_OVERFLOW = -5,
+	ROTCTLD_READ_FAILED = -6,
 };
 typedef enum rotctld_error_e rotctld_error;
 


### PR DESCRIPTION
Ref. https://github.com/la1k/flyby/issues/108: Flyby singletrack UI can
become unresponsive during tracking since we wait for confirmation of
the previous response before we try to set a new position.

These changes modify the socket read to be non-blocking, so that we can
return back to the UI loop when the full response is not available yet,
and still retain the mechanism with the previous response being required
before we are allowed to set a new position.

This does not fully solve https://github.com/la1k/flyby/issues/108 since
we will have an issue with the hamlib status windows, but I'll continue
on that in a different branch and merge this already now so that the
user experience can be improved.